### PR TITLE
Add more typings

### DIFF
--- a/gulp-file.ts
+++ b/gulp-file.ts
@@ -1,8 +1,12 @@
-/// <reference path='typings/node/node.d.ts' />
+import * as gulp from 'gulp';
+import * as ts from 'gulp-typescript';
+import * as tslint from 'gulp-tslint';
+import * as sourcemaps from 'gulp-sourcemaps';
+import * as concat from 'gulp-concat';
+import * as del from 'del';
 
-let gulp = require('gulp'),
-    ts = require('gulp-typescript'),
-    sourcemaps = require('gulp-sourcemaps');
+// Not all modules can be imported with the ES6 syntax, (see https://github.com/Microsoft/TypeScript/issues/3612),
+// so some have been left using the ES5 'require' syntax, inline.
 
 let build = (src: string, dest: string) => gulp.src(src)
     .pipe(sourcemaps.init())
@@ -62,16 +66,13 @@ let startServer = () => {
 };
 
 gulp.task('lint', () => {
-    let tslint = require('gulp-tslint');
-
     return gulp.src([files.src.ts, files.tests.ts, files.site.ts, files.gulp])
         .pipe(tslint({}))
         .pipe(tslint.report('verbose'));
 });
 
 gulp.task('clean', () => {
-    let del = require('del'),
-        src = [files.src.js, files.src.maps],
+    let src = [files.src.js, files.src.maps],
         tests = [files.tests.js, files.tests.maps],
         dist = [paths.src.dist + wildcard, paths.site.app + wildcard];
 
@@ -110,8 +111,6 @@ gulp.task('build:less', () => {
 gulp.task('build', ['build:tests', 'build:src', 'build:appsrc', 'build:less']);
 
 gulp.task('concat', ['build', 'test'], () => {
-    let concat = require('gulp-concat');
-
     return gulp.src(files.src.js)
         .pipe(concat(files.releaseName))
         .pipe(gulp.dest(paths.src.dist));

--- a/tsd.json
+++ b/tsd.json
@@ -19,6 +19,33 @@
     },
     "q/Q.d.ts": {
       "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "gulp-typescript/gulp-typescript.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "gulp-sourcemaps/gulp-sourcemaps.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "minimatch/minimatch.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "glob/glob.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "del/del.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "es6-promise/es6-promise.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "vinyl/vinyl.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "gulp-tslint/gulp-tslint.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
+    },
+    "gulp-concat/gulp-concat.d.ts": {
+      "commit": "fc341765ebbb04b7109981a25dced01f488f4d94"
     }
   }
 }


### PR DESCRIPTION
Use the es6 style import for modules. Using this style also provides the benefit of working intellisense in VS2015.

Unfortunately, as per the comment, not all libraries can be imported in this way. This means that for those libraries there is no intellisense in VS.

Given imports must be defined at module level many of them have moved from being declared inline to the top (they're hoisted anyway). However, I've left the 'old' style `require` lines inline, where they're used.